### PR TITLE
feat(js): control bond prediction and final-frame filtering in animateGeneration

### DIFF
--- a/js/src/conformerGenerator.js
+++ b/js/src/conformerGenerator.js
@@ -288,11 +288,29 @@ export class MLConformerGenerator {
 
   /**
    * Streaming variant of `generateConformers`: yields one frame per denoising
-   * step, each frame being the batch decoded to molecules at that step.
-   * Intermediate frames are atom clouds only (no AdjMatSeer); bonds are
-   * predicted on the final frame. The optional EDM (RL fine-tune) adapter is
-   * not applied per frame.
+   * step, each frame being the batch decoded to molecules at that step. The
+   * optional EDM (RL fine-tune) adapter is not applied per frame.
    *
+   * Bond prediction is controlled by `predictBonds`:
+   *   - `"last"` (default) — AdjMatSeer on the final frame only. Intermediate
+   *     frames are atom clouds, which is what a trajectory view wants, and the
+   *     whole animation costs one extra inference.
+   *   - `"always"` — AdjMatSeer on every frame, so a viewer can show real
+   *     connectivity forming instead of guessing bonds by distance. Costs one
+   *     AdjMatSeer call per denoising step.
+   *   - `"never"` — atom clouds only, no bonds at any point.
+   *
+   * By default the final frame carries bonds but is NOT put through the
+   * `standardizeMol` / largest-fragment / validity pass that
+   * `generateConformers` applies, so it may be multi-fragment or fail RDKit
+   * sanitize. Pass `filterInvalid: true` to run that pass on the final frame
+   * and get a frame equivalent to a `generateConformers` result — note it can
+   * drop molecules, so the final frame may be shorter than the frames before
+   * it (possibly empty). Filtering is only ever applied to the final frame.
+   *
+   * @param {"last"|"never"|"always"} [predictBonds="last"]
+   * @param {boolean} [filterInvalid=false] standardize + validity-filter the final frame
+   * @param {boolean} [keepLargestFragment=true] only meaningful with `filterInvalid`
    * @returns {AsyncGenerator<{ step: number, total: number, molecules: object[] }>}
    */
   async *animateGeneration({
@@ -302,7 +320,21 @@ export class MLConformerGenerator {
     nSamples = 1,
     variance = 2,
     resampleSteps = 0,
+    predictBonds = "last",
+    filterInvalid = false,
+    keepLargestFragment = true,
   } = {}) {
+    if (!["last", "never", "always"].includes(predictBonds)) {
+      throw new TypeError(
+        `Invalid predictBonds "${predictBonds}" — expected "last", "never" or "always".`,
+      );
+    }
+    if (filterInvalid && predictBonds === "never") {
+      throw new TypeError(
+        'filterInvalid needs bonds on the final frame — use predictBonds "last" or "always".',
+      );
+    }
+
     const prepared = this.prepareInputs({
       referenceConformer,
       referenceContext,
@@ -331,12 +363,24 @@ export class MLConformerGenerator {
       batchContext,
       resampleSteps,
     )) {
+      const isFinal = frame.step === frame.total;
       let mols = samplesToMolecules(frame.x, frame.h, nodeMask, this.atomDecoder);
-      // AdjMatSeer only on the last denoising step (expensive; earlier frames
-      // are for trajectory visualisation of the atom cloud).
-      if (frame.step === frame.total) {
+
+      if (predictBonds === "always" || (predictBonds === "last" && isFinal)) {
         mols = await this.predictBonds(mols);
       }
+
+      // Final frame only: mirror the generateConformers post-processing so the
+      // last frame can be used as the result rather than just as a picture.
+      if (isFinal && filterInvalid) {
+        const valid = [];
+        for (const mol of mols) {
+          const std = await standardizeMol(mol, { keepLargestFragment });
+          if (std) valid.push(std);
+        }
+        mols = valid;
+      }
+
       yield { step: frame.step, total: frame.total, molecules: mols };
     }
   }

--- a/js/test/conformer_generator_mock.test.js
+++ b/js/test/conformer_generator_mock.test.js
@@ -76,6 +76,31 @@ const mockOrt = {
 };
 
 describe("MLConformerGenerator pipeline (mock ORT, no weights)", () => {
+  /** Generator wired to the mock ORT with a short 5-step trajectory. */
+  async function animGenerator() {
+    return createGenerator({
+      ort: mockOrt,
+      egnnOnnx: "egnn.onnx",
+      adjMatSeerOnnx: "adj.onnx",
+      diffusionSteps: 5,
+    });
+  }
+
+  /** Drain animateGeneration into an array, with a fixed reference context. */
+  async function collectFrames(gen, opts = {}) {
+    const frames = [];
+    for await (const f of gen.animateGeneration({
+      referenceContext: [89.8693, 210.783, 217.7825],
+      nAtoms: 20,
+      nSamples: 2,
+      variance: 0,
+      ...opts,
+    })) {
+      frames.push(f);
+    }
+    return frames;
+  }
+
   it("generateConformers returns nSamples molecules with valid MOL blocks", async () => {
     const gen = await createGenerator({
       ort: mockOrt,
@@ -150,12 +175,77 @@ describe("MLConformerGenerator pipeline (mock ORT, no weights)", () => {
       assert.equal(f.molecules.length, 2);
       for (const m of f.molecules) assert.ok(m.nAtoms >= 1);
     }
-    // Bonds only on the final frame (AdjMatSeer).
+    // Bonds only on the final frame (AdjMatSeer), i.e. predictBonds: "last".
     for (const f of frames.slice(0, -1)) {
       for (const m of f.molecules) assert.equal(m.bonds.length, 0);
     }
     for (const m of frames[frames.length - 1].molecules) {
       assert.ok(m.bonds.length > 0);
+    }
+  });
+
+  it('animateGeneration predictBonds: "always" bonds every frame', async () => {
+    const gen = await animGenerator();
+    const frames = await collectFrames(gen, { predictBonds: "always" });
+
+    assert.equal(frames.length, 5);
+    for (const f of frames) {
+      for (const m of f.molecules) assert.ok(m.bonds.length > 0);
+    }
+  });
+
+  it('animateGeneration predictBonds: "never" bonds no frame', async () => {
+    const gen = await animGenerator();
+    const frames = await collectFrames(gen, { predictBonds: "never" });
+
+    assert.equal(frames.length, 5);
+    for (const f of frames) {
+      for (const m of f.molecules) assert.equal(m.bonds.length, 0);
+    }
+  });
+
+  it("animateGeneration rejects an unknown predictBonds mode", async () => {
+    const gen = await animGenerator();
+    await assert.rejects(
+      () => collectFrames(gen, { predictBonds: "sometimes" }),
+      /Invalid predictBonds/,
+    );
+  });
+
+  it('animateGeneration rejects filterInvalid with predictBonds: "never"', async () => {
+    const gen = await animGenerator();
+    await assert.rejects(
+      () => collectFrames(gen, { predictBonds: "never", filterInvalid: true }),
+      /filterInvalid needs bonds/,
+    );
+  });
+
+  it("animateGeneration filterInvalid standardizes only the final frame", async () => {
+    const gen = await animGenerator();
+
+    seed(3);
+    const unfiltered = await collectFrames(gen, {});
+    seed(3);
+    const filtered = await collectFrames(gen, { filterInvalid: true });
+
+    // Same trajectory length and identical intermediate frames — filtering is
+    // confined to the last frame and must not perturb the ones before it.
+    assert.equal(filtered.length, unfiltered.length);
+    for (let i = 0; i < filtered.length - 1; i += 1) {
+      assert.equal(filtered[i].molecules.length, 2);
+      assert.deepEqual(
+        filtered[i].molecules.map((m) => m.nAtoms),
+        unfiltered[i].molecules.map((m) => m.nAtoms),
+      );
+    }
+
+    // Final frame: a subset of the unfiltered batch, every survivor a single
+    // connected fragment (keepLargestFragment defaults to true).
+    const finalFiltered = filtered[filtered.length - 1].molecules;
+    assert.equal(unfiltered[unfiltered.length - 1].molecules.length, 2);
+    assert.ok(finalFiltered.length <= 2);
+    for (const m of finalFiltered) {
+      assert.equal(m.fragmentCount(), 1);
     }
   });
 });


### PR DESCRIPTION
Add predictBonds modes (last/always/never) and optional filterInvalid on the last frame so trajectory viewers can show connectivity forming or treat the final frame like generateConformers output.