### PR TITLE
fix(js): load RDKit in browser and surface load failures

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -54,8 +54,40 @@ for (const mol of mols) {
 ```
 
 `createGenerator(options)` takes the ONNX Runtime namespace as the `ort` option.
+
+### Browser
+
 To run in the browser (or any WebAssembly build), install `onnxruntime-web` and pass it
-instead: `import * as ort from "onnxruntime-web"`.
+instead:
+
+```js
+import { createGenerator } from "mlconfgen";
+import * as ort from "onnxruntime-web";
+
+// Weights loaded from the user's own machine (e.g. an <input type="file">),
+// so they are never uploaded or re-hosted.
+const gen = await createGenerator({
+  ort,
+  egnnOnnx: new Uint8Array(await egnnFile.arrayBuffer()),
+  adjMatSeerOnnx: new Uint8Array(await adjFile.arrayBuffer()),
+});
+```
+
+RDKit is resolved automatically for the runtime it finds, so no extra wiring is needed
+under a bundler (Vite, webpack, …), from a `<script>` tag that defines a global
+`initRDKitModule`, or with no bundler at all. Pass `rdkitLoader` only to pin a specific
+RDKit build:
+
+```js
+const gen = await createGenerator({
+  ort,
+  rdkitLoader: () => initRDKitModule({ locateFile: () => "/wasm/RDKit_minimal.wasm" }),
+});
+```
+
+The weights are **not** published on npm and are licensed CC BY-NC-ND — download them
+from Hugging Face and keep them local to your machine or application. Point
+`egnnOnnx` / `adjMatSeerOnnx` at those local files, as in the example above.
 
 You can pass coordinates and let the package compute the context:
 
@@ -66,7 +98,13 @@ const mols = await gen.generateConformers({
 });
 ```
 
-RDKit (bundled `@rdkit/rdkit`) is used automatically for validity filtering and SMILES canonicalisation. To supply your own build (e.g. a browser WASM RDKit), pass a `rdkitLoader` function to `createGenerator`.
+RDKit (bundled `@rdkit/rdkit`) is used automatically for validity filtering and SMILES
+canonicalisation, in both Node and the browser. Pass a `rdkitLoader` function to
+`createGenerator` to supply your own build.
+
+If RDKit is configured but fails to initialise, generation throws an error named
+`RdkitLoadError` rather than quietly treating every molecule as invalid and
+returning an empty result set.
 
 ## Tests
 
@@ -92,7 +130,7 @@ Optional env vars: `PORT`, `EGNN_ONNX`, `ADJ_ONNX`.
 
 ## Notes / limitations
 
-- **Runtime** — bring your own ONNX Runtime (`onnxruntime-node` or `onnxruntime-web`), passed to `createGenerator` as `ort`. `@rdkit/rdkit` is bundled. Node 18+.
+- **Runtime** — bring your own ONNX Runtime (`onnxruntime-node` or `onnxruntime-web`), passed to `createGenerator` as `ort`. `@rdkit/rdkit` is bundled and loads in both Node and the browser. Node 18+.
 - **RDKit.js** — SMILES atom-order canonicalisation before AdjMatSeer, plus validity filtering via sanitize.
 - **Validity** — `generateConformers` defaults to `filterInvalid: true`.
 - **RNG / float64** — same `seed(n)` as `np.random.seed(n)`.

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlconfgen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Spatially-aware molecule generation via equivariant diffusion (ONNX Runtime)",
   "type": "module",
   "main": "./src/index.js",

--- a/js/src/mol.js
+++ b/js/src/mol.js
@@ -6,7 +6,7 @@ import {
   NUM_BOND_TYPES,
 } from "./constants.js";
 import { numpyRandint } from "./numpyRandom.js";
-import { getRdkit, hasRdkitLoader } from "./rdkit.js";
+import { getRdkit, hasRdkitLoader, RdkitLoadError } from "./rdkit.js";
 import { zeros } from "./tensor.js";
 
 /** Lightweight molecule: atoms + coordinates + bonds. */
@@ -325,7 +325,8 @@ export async function canonicalise(mol) {
 
     if (!order) return connected;
     return permuteMolecule(connected, order);
-  } catch {
+  } catch (err) {
+    if (err instanceof RdkitLoadError) throw err;
     return connected;
   }
 }
@@ -474,7 +475,8 @@ export async function isValidMol(mol) {
     const ok = rdMol.is_valid();
     rdMol.delete();
     return ok ? 1 : 0;
-  } catch {
+  } catch (err) {
+    if (err instanceof RdkitLoadError) throw err;
     return 0;
   }
 }
@@ -520,7 +522,8 @@ export async function standardizeMol(
     }
     rdMol.delete();
     return out;
-  } catch {
+  } catch (err) {
+    if (err instanceof RdkitLoadError) throw err;
     return null;
   }
 }

--- a/js/src/rdkit.js
+++ b/js/src/rdkit.js
@@ -28,6 +28,25 @@ export function hasRdkitLoader() {
 }
 
 /**
+ * Raised when a registered RDKit loader exists but fails to initialise.
+ *
+ * Distinct from "no loader configured" (see `hasRdkitLoader`) so callers can
+ * tell a broken RDKit apart from a genuinely invalid molecule instead of
+ * silently reporting every molecule as invalid.
+ */
+export class RdkitLoadError extends Error {
+  constructor(cause) {
+    super(
+      `RDKit failed to initialise: ${cause?.message ?? cause}. ` +
+        "In the browser, ensure the bundled @rdkit/rdkit can resolve its " +
+        "RDKit_minimal.wasm, or pass a custom `rdkitLoader` to createGenerator().",
+      { cause },
+    );
+    this.name = "RdkitLoadError";
+  }
+}
+
+/**
  * @returns {Promise<any>}
  * @throws {Error} if no loader has been registered
  */
@@ -38,25 +57,110 @@ export function getRdkit() {
     );
   }
   if (!rdkitPromise) {
-    rdkitPromise = Promise.resolve().then(() => rdkitLoader());
+    rdkitPromise = Promise.resolve()
+      .then(() => rdkitLoader())
+      .catch((err) => {
+        throw new RdkitLoadError(err);
+      });
   }
   return rdkitPromise;
 }
 
+const IS_NODE =
+  typeof process !== "undefined" && process.versions?.node != null;
+
 /**
- * Default Node loader for `@rdkit/rdkit` (WASM next to the package).
- * Called once from the package entry so `npm install mlconfgen` is enough.
+ * Node: resolve the bundled WASM through the module graph, since Emscripten
+ * cannot infer its own location outside a browser.
+ */
+async function loadRdkitNode() {
+  const { createRequire } = await import("node:module");
+  const path = await import("node:path");
+  const require = createRequire(import.meta.url);
+  const pkgDir = path.dirname(require.resolve("@rdkit/rdkit/package.json"));
+  const initRDKitModule = (await import("@rdkit/rdkit")).default;
+  return initRDKitModule({
+    locateFile: () => path.join(pkgDir, "dist", "RDKit_minimal.wasm"),
+  });
+}
+
+/**
+ * Browser / worker: `RDKit_minimal.js` locates its own `.wasm` relative to the
+ * script URL, so no `locateFile` is needed.
+ *
+ * Three setups, tried in order:
+ *   1. a global `initRDKitModule` from a plain <script> tag;
+ *   2. a bundler (Vite/webpack/…) that interops the CommonJS build into a
+ *      usable `default` export;
+ *   3. no bundler — `RDKit_minimal.js` is UMD and yields *no* ES exports when
+ *      imported directly, so it has to be injected as a classic script.
+ *
+ * Anything more exotic should pass an explicit `rdkitLoader`.
+ */
+async function loadRdkitBrowser() {
+  if (typeof globalThis.initRDKitModule === "function") {
+    return globalThis.initRDKitModule();
+  }
+
+  try {
+    const mod = await import("@rdkit/rdkit");
+    const init = mod?.default ?? mod?.initRDKitModule;
+    if (typeof init === "function") return init();
+  } catch {
+    // Not resolvable as a module here; fall through to the script-tag path.
+  }
+
+  const init = await loadRdkitViaScriptTag();
+  return init();
+}
+
+const RDKIT_CDN =
+  "https://cdn.jsdelivr.net/npm/@rdkit/rdkit@2025.3.4-1.0.0/dist/RDKit_minimal.js";
+
+/** @type {Promise<Function> | null} */
+let scriptTagPromise = null;
+
+/**
+ * Inject the UMD build so it installs `globalThis.initRDKitModule`.
+ * Only used when there is no bundler and no pre-existing global.
+ */
+function loadRdkitViaScriptTag(src = RDKIT_CDN) {
+  if (scriptTagPromise) return scriptTagPromise;
+  if (typeof document === "undefined") {
+    return Promise.reject(
+      new Error(
+        "No DOM available to load RDKit — pass an explicit `rdkitLoader` " +
+          "(e.g. importScripts in a worker).",
+      ),
+    );
+  }
+
+  scriptTagPromise = new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.onload = () => {
+      const init = globalThis.initRDKitModule;
+      if (typeof init === "function") resolve(init);
+      else reject(new Error(`Loaded ${src} but initRDKitModule is missing.`));
+    };
+    script.onerror = () => reject(new Error(`Failed to load ${src}`));
+    document.head.appendChild(script);
+  }).catch((err) => {
+    scriptTagPromise = null;
+    throw err;
+  });
+
+  return scriptTagPromise;
+}
+
+/**
+ * Default loader for the bundled `@rdkit/rdkit`, picked to match the runtime so
+ * that `npm install mlconfgen` is enough in both Node and the browser.
+ * Override with `setRdkitLoader` / the `rdkitLoader` option when embedding a
+ * custom RDKit build.
  */
 export function registerDefaultRdkit() {
   if (hasRdkitLoader()) return;
-  setRdkitLoader(async () => {
-    const { createRequire } = await import("node:module");
-    const path = await import("node:path");
-    const require = createRequire(import.meta.url);
-    const pkgDir = path.dirname(require.resolve("@rdkit/rdkit/package.json"));
-    const initRDKitModule = (await import("@rdkit/rdkit")).default;
-    return initRDKitModule({
-      locateFile: () => path.join(pkgDir, "dist", "RDKit_minimal.wasm"),
-    });
-  });
+  setRdkitLoader(() => (IS_NODE ? loadRdkitNode() : loadRdkitBrowser()));
 }

--- a/js/test/unit/rdkit_loader.test.js
+++ b/js/test/unit/rdkit_loader.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isValidMol, Molecule, standardizeMol } from "../../src/mol.js";
+import {
+  clearRdkitLoader,
+  hasRdkitLoader,
+  RdkitLoadError,
+  registerDefaultRdkit,
+  setRdkitLoader,
+} from "../../src/rdkit.js";
+
+/** Ethanol-like C-C-O; sanitizes cleanly. */
+function validMolecule() {
+  return new Molecule({
+    atomicNumbers: [6, 6, 8],
+    positions: Float32Array.from([0, 0, 0, 1.5, 0, 0, 2.4, 1.0, 0]),
+    bonds: [
+      { i: 0, j: 1, type: 1 },
+      { i: 1, j: 2, type: 1 },
+    ],
+  });
+}
+
+/** Hypervalent carbon: six single bonds, so sanitize must reject it. */
+function invalidMolecule() {
+  return new Molecule({
+    atomicNumbers: [6, 6, 6, 6, 6, 6, 6],
+    positions: Float32Array.from([
+      0, 0, 0, 1.5, 0, 0, -1.5, 0, 0, 0, 1.5, 0, 0, -1.5, 0, 0, 0, 1.5, 0, 0,
+      -1.5,
+    ]),
+    bonds: [1, 2, 3, 4, 5, 6].map((j) => ({ i: 0, j, type: 1 })),
+  });
+}
+
+test("rdkit loader", async (t) => {
+  t.afterEach(() => {
+    clearRdkitLoader();
+    registerDefaultRdkit();
+  });
+
+  await t.test("a failing loader throws instead of reporting invalid", async () => {
+    // Regression: the browser default used to import `node:module`, which threw
+    // and was swallowed by the call sites, so every molecule silently came back
+    // invalid and generateConformers returned []. A broken RDKit must be loud.
+    setRdkitLoader(async () => {
+      throw new Error("Failed to resolve module specifier 'node:module'");
+    });
+
+    await assert.rejects(() => isValidMol(validMolecule()), RdkitLoadError);
+    await assert.rejects(() => standardizeMol(validMolecule()), RdkitLoadError);
+  });
+
+  await t.test("load failure is distinguishable from invalid chemistry", async () => {
+    setRdkitLoader(async () => {
+      throw new Error("boom");
+    });
+
+    const err = await isValidMol(validMolecule()).catch((e) => e);
+    assert.ok(err instanceof RdkitLoadError);
+    assert.match(err.message, /rdkitLoader/);
+    assert.equal(err.cause?.message, "boom");
+  });
+
+  await t.test("default loader works with no configuration", async () => {
+    clearRdkitLoader();
+    registerDefaultRdkit();
+    assert.ok(hasRdkitLoader());
+
+    assert.equal(await isValidMol(validMolecule()), 1);
+    assert.notEqual(await standardizeMol(validMolecule()), null);
+  });
+
+  await t.test("genuinely invalid molecules are still rejected, not thrown", async () => {
+    clearRdkitLoader();
+    registerDefaultRdkit();
+
+    assert.equal(await isValidMol(invalidMolecule()), 0);
+    assert.equal(await standardizeMol(invalidMolecule()), null);
+  });
+
+  await t.test("an explicit rdkitLoader overrides the default", async () => {
+    clearRdkitLoader();
+    let called = 0;
+    setRdkitLoader(async () => {
+      called += 1;
+      const { default: init } = await import("@rdkit/rdkit");
+      const { createRequire } = await import("node:module");
+      const path = await import("node:path");
+      const require = createRequire(import.meta.url);
+      const dir = path.dirname(require.resolve("@rdkit/rdkit/package.json"));
+      return init({
+        locateFile: () => path.join(dir, "dist", "RDKit_minimal.wasm"),
+      });
+    });
+
+    assert.equal(await isValidMol(validMolecule()), 1);
+    assert.equal(called, 1, "custom loader should be used");
+  });
+});


### PR DESCRIPTION
Pick a Node vs browser default loader so generation no longer silently returns empty when node:module fails in the browser. Introduce RdkitLoadError, rethrow it from mol helpers, document browser setup, and bump to 0.1.1.